### PR TITLE
Resolve dependency upgrade issues

### DIFF
--- a/ha/addon/Dockerfile
+++ b/ha/addon/Dockerfile
@@ -2,8 +2,10 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 ARG BUILD_VERSION
-RUN apk add --no-cache py3-pip
-RUN pip install haco==${BUILD_VERSION}
+RUN apk add --no-cache pipx
+ENV PATH="${PATH}:/root/.local/bin"
+
+RUN pipx install haco==${BUILD_VERSION}
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/ha/addon/Dockerfile
+++ b/ha/addon/Dockerfile
@@ -7,6 +7,9 @@ ENV PATH="${PATH}:/root/.local/bin"
 
 RUN pipx install haco==${BUILD_VERSION}
 
+# Remove one haco is either updated to support aiomqtt 2.0.0 or specifies needed version in setup.py
+RUN pipx inject haco aiomqtt==1.2.1
+
 COPY run.sh /
 RUN chmod a+x /run.sh
 


### PR DESCRIPTION
Looks like there was 2 dependency upgrades which caused issues with haco. 

The first looks like alpine started not liking bare pip installs and wants everything to either be a system package or in an venv. Used pipx to put haco in a venv. It's a container so it really shouldn't matter, but it makes alpine happy

The 2nd is there looks to have been a LOT of breaking changes to aiomqtt in version 2. Hacked the docker install to install the last of major version 1. Figure it's a temp solution until haco can be updated to support aiomqtt 2 or the setup.py is updated to lock down the needed version